### PR TITLE
Intern attribute type

### DIFF
--- a/Sources/OpenAttributeGraph/Attribute/Attribute/Attribute.swift
+++ b/Sources/OpenAttributeGraph/Attribute/Attribute/Attribute.swift
@@ -114,11 +114,12 @@ public struct Attribute<Value> {
         }
         let index = Graph.typeIndex(
             ctx: context,
-            body: Body.self,
-            valueType: Metadata(Value.self),
-            flags: flags,
-            update: update
-        )
+            body: Metadata(Body.self)
+        ) {
+            let pointer = UnsafeMutablePointer<_AttributeType>.allocate(capacity: 1)
+            // TODO
+            return UnsafePointer(pointer)
+        }
         identifier = OAGGraphCreateAttribute(index: index, body: body, value: value)
         #endif
     }

--- a/Sources/OpenAttributeGraph/Graph/Graph.swift
+++ b/Sources/OpenAttributeGraph/Graph/Graph.swift
@@ -8,16 +8,12 @@
 public import OpenAttributeGraphCxx
 
 extension Graph {
+    @_silgen_name("OAGGraphInternAttributeType")
     public static func typeIndex(
         ctx: UnownedGraphContext,
-        body: _AttributeBody.Type,
-        valueType: Metadata,
-        flags: _AttributeType.Flags,
-        update: AttributeUpdateBlock
-    ) -> Int {
-        // TODO: __AGGraphInternAttributeType
-        0
-    }
+        body: Metadata,
+        makeAttributeType: () -> UnsafePointer<_AttributeType>
+    ) -> Int
 }
 
 @_silgen_name("OAGGraphSetInvalidationCallback")

--- a/Sources/OpenAttributeGraph/Graph/Graph.swift
+++ b/Sources/OpenAttributeGraph/Graph/Graph.swift
@@ -9,7 +9,7 @@ public import OpenAttributeGraphCxx
 
 extension Graph {
     public static func typeIndex(
-        ctx: GraphContext,
+        ctx: UnownedGraphContext,
         body: _AttributeBody.Type,
         valueType: Metadata,
         flags: _AttributeType.Flags,

--- a/Sources/OpenAttributeGraph/OpenAttributeGraph.docc/Graph/Dependency-Graphs.md
+++ b/Sources/OpenAttributeGraph/OpenAttributeGraph.docc/Graph/Dependency-Graphs.md
@@ -22,7 +22,7 @@ Graphs automatically track dependencies as attributes access other attributes du
 
 ### Graph Management
 
-- ``Graph/typeIndex(ctx:body:valueType:flags:update:)``
+- ``Graph/typeIndex(ctx:body:makeAttributeType:)``
 - ``Subgraph/currentGraphContext``
 
 ### Update Coordination

--- a/Sources/OpenAttributeGraphCxx/Graph/OAGGraph.cpp
+++ b/Sources/OpenAttributeGraphCxx/Graph/OAGGraph.cpp
@@ -110,11 +110,11 @@ void OAGGraphSetContext(OAGGraphRef graph, const void * _Nullable context) {
     graph->context.set_context(context);
 }
 
-OAGGraphContextRef OAGGraphGetGraphContext(OAGGraphRef graph) {
+OAGUnownedGraphContextRef OAGGraphGetGraphContext(OAGGraphRef graph) {
     if (graph->context.isInvalid()) {
         OAG::precondition_failure("invalidated graph");
     }
-    return reinterpret_cast<OAGGraphContextRef>(reinterpret_cast<uintptr_t>(graph) + sizeof(CFRuntimeBase));
+    return reinterpret_cast<OAGUnownedGraphContextRef>(&graph->context.get_graph());
 }
 
 void OAGGraphInvalidate(OAGGraphRef graph) {

--- a/Sources/OpenAttributeGraphCxx/Graph/OAGGraph.cpp
+++ b/Sources/OpenAttributeGraphCxx/Graph/OAGGraph.cpp
@@ -125,6 +125,13 @@ void OAGGraphInvalidate(OAGGraphRef graph) {
     graph->context.setInvalid(true);
 }
 
+uint32_t OAGGraphInternAttributeType(OAGUnownedGraphContextRef graph, OAGTypeID type,
+                                    const OAGAttributeType *(*make_attribute_type)(const void *context OAG_SWIFT_CONTEXT) OAG_SWIFT_CC(swift),
+                                    const void *context) {
+    // TODO
+    return 0;
+}
+
 void OAGGraphInvalidateAllValues(OAGGraphRef graph) {
     if (graph->context.isInvalid()) {
         OAG::precondition_failure("invalidated graph");

--- a/Sources/OpenAttributeGraphCxx/Graph/OAGGraphContext.cpp
+++ b/Sources/OpenAttributeGraphCxx/Graph/OAGGraphContext.cpp
@@ -5,6 +5,6 @@
 #include <OpenAttributeGraph/OAGGraphContext.h>
 #include <OpenAttributeGraph/Private/CFRuntime.h>
 
-OAGGraphRef OAGGraphContextGetGraph(OAGGraphContextRef context) {
+OAGGraphRef OAGGraphContextGetGraph(void *context) {
     return reinterpret_cast<OAGGraphRef>(reinterpret_cast<uintptr_t>(context) - sizeof(CFRuntimeBase));
 }

--- a/Sources/OpenAttributeGraphCxx/Graph/OAGSubgraph.cpp
+++ b/Sources/OpenAttributeGraphCxx/Graph/OAGSubgraph.cpp
@@ -95,12 +95,13 @@ void OAGSubgraphSetCurrent(_Nullable OAGSubgraphRef cf_subgraph) {
     }
 }
 
-OAGGraphContextRef OAGSubgraphGetCurrentGraphContext() {
+OAGUnownedGraphContextRef OAGSubgraphGetCurrentGraphContext() {
     OAG::Subgraph *subgraph = OAG::Subgraph::get_current();
     if (subgraph == nullptr) {
         return nullptr;
     }
-    return subgraph->get_context();
+    OAG::Graph &graph = subgraph->get_graph();
+    return reinterpret_cast<OAGUnownedGraphContextRef>(&graph);
 }
 
 void OAGSubgraphInvalidate(OAGSubgraphRef cf_subgraph) {
@@ -121,7 +122,8 @@ OAGGraphRef OAGSubgraphGetGraph(OAGSubgraphRef cf_subgraph) {
     if (cf_subgraph->subgraph == nullptr) {
         OAG::precondition_failure("accessing invalidated subgraph");
     }
-    return OAGGraphContextGetGraph(cf_subgraph->subgraph->get_context());
+    // TODO
+    return nullptr;
 }
 
 void OAGSubgraphAddChild(OAGSubgraphRef parent, OAGSubgraphRef child) {

--- a/Sources/OpenAttributeGraphCxx/Graph/Subgraph.cpp
+++ b/Sources/OpenAttributeGraphCxx/Graph/Subgraph.cpp
@@ -23,9 +23,8 @@ void OAG::Subgraph::apply(OAGAttributeFlags flags, OAG::ClosureFunction<void, OA
     // TODO
 }
 
-OAG::Subgraph::Subgraph(OAG::SubgraphObject* cf_subgraph, OAG::Graph::Context& context, OAG::AttributeID):
-_cf_subgraph((OAGSubgraphRef)cf_subgraph), // FIXME
-_context((OAGGraphContextStorage &)context){
+OAG::Subgraph::Subgraph(OAG::SubgraphObject* object, OAG::Graph::Context& context, OAG::AttributeID):
+_object(object), _graph(context.get_graph()), _graph_context_id(context.get_id()) {
     // TODO
 }
 

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGGraph.h
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGGraph.h
@@ -13,11 +13,11 @@
 
 typedef struct OAG_BRIDGED_TYPE(id) OAGGraphStorage * OAGGraphRef OAG_SWIFT_NAME(Graph);
 typedef struct OAG_BRIDGED_TYPE(id) OAGSubgraphStorage * OAGSubgraphRef OAG_SWIFT_NAME(Subgraph);
-typedef struct OAG_BRIDGED_TYPE(id) OAGGraphContextStorage * OAGGraphContextRef OAG_SWIFT_NAME(GraphContext);
+typedef struct OAGGraphContextStorage * OAGUnownedGraphContextRef OAG_SWIFT_STRUCT OAG_SWIFT_NAME(UnownedGraphContext);
 
 struct OAGGraphStorage;
-struct OAGGraphContextStorage;
 struct OAGSubgraphStorage;
+struct OAGGraphContextStorage;
 
 typedef uint32_t OAGAttribute OAG_SWIFT_STRUCT OAG_SWIFT_NAME(AnyAttribute);
 
@@ -63,7 +63,7 @@ void OAGGraphSetContext(OAGGraphRef graph, const void * _Nullable context) OAG_S
 
 OAG_EXPORT
 OAG_REFINED_FOR_SWIFT
-OAGGraphContextRef OAGGraphGetGraphContext(OAGGraphRef graph) OAG_SWIFT_NAME(getter:OAGGraphRef.graphContext(self:));
+OAGUnownedGraphContextRef OAGGraphGetGraphContext(OAGGraphRef graph) OAG_SWIFT_NAME(getter:OAGGraphRef.graphContext(self:));
 
 OAG_EXPORT
 OAG_REFINED_FOR_SWIFT

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGGraph.h
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGGraph.h
@@ -7,6 +7,7 @@
 
 #include <OpenAttributeGraph/OAGBase.h>
 #include <OpenAttributeGraph/Private/CFRuntime.h>
+#include <OpenAttributeGraph/OAGAttributeType.h>
 #include <OpenAttributeGraph/OAGGraphCounterQueryType.h>
 
 // Note: Place all structure declaration in a single place to avoid header cycle dependency
@@ -68,6 +69,12 @@ OAGUnownedGraphContextRef OAGGraphGetGraphContext(OAGGraphRef graph) OAG_SWIFT_N
 OAG_EXPORT
 OAG_REFINED_FOR_SWIFT
 void OAGGraphInvalidate(OAGGraphRef graph) OAG_SWIFT_NAME(OAGGraphRef.invalidate(self:));
+
+OAG_EXPORT
+OAG_REFINED_FOR_SWIFT
+uint32_t OAGGraphInternAttributeType(OAGUnownedGraphContextRef graph, OAGTypeID type,
+                                    const OAGAttributeType * _Nonnull (* _Nonnull make_attribute_type)(const void * _Nullable context OAG_SWIFT_CONTEXT) OAG_SWIFT_CC(swift),
+                                    const void * _Nullable context);
 
 OAG_EXPORT
 OAG_REFINED_FOR_SWIFT

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGGraphContext.h
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGGraphContext.h
@@ -18,7 +18,7 @@ OAG_EXTERN_C_BEGIN
 
 OAG_EXPORT
 OAG_REFINED_FOR_SWIFT
-OAGGraphRef OAGGraphContextGetGraph(OAGGraphContextRef context) OAG_SWIFT_NAME(getter:OAGGraphContextRef.graph(self:));
+OAGGraphRef OAGGraphContextGetGraph(void *context);
 
 OAG_EXTERN_C_END
 

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGSubgraph.h
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGSubgraph.h
@@ -42,7 +42,7 @@ void OAGSubgraphSetCurrent(_Nullable OAGSubgraphRef cf_subgraph) OAG_SWIFT_NAME(
 
 OAG_EXPORT
 OAG_REFINED_FOR_SWIFT
-_Nullable OAGGraphContextRef OAGSubgraphGetCurrentGraphContext(void) OAG_SWIFT_NAME(getter:OAGSubgraphRef.currentGraphContext());
+_Nullable OAGUnownedGraphContextRef OAGSubgraphGetCurrentGraphContext(void) OAG_SWIFT_NAME(getter:OAGSubgraphRef.currentGraphContext());
 
 OAG_EXPORT
 OAG_REFINED_FOR_SWIFT

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraphCxx/Graph/Graph.hpp
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraphCxx/Graph/Graph.hpp
@@ -64,6 +64,11 @@ public:
             _context = context;
         }
         
+        OAG_INLINE OAG_CONSTEXPR
+        OAGUniqueID get_id() OAG_NOEXCEPT {
+            return _id;
+        }
+        
         OAG_INLINE
         void set_invalidation_callback(ClosureFunction<void, OAGAttribute> invalidation_callback) OAG_NOEXCEPT {
             _invalidation_callback = invalidation_callback;
@@ -181,7 +186,7 @@ struct OAGGraphStorage {
 };
 
 struct OAGGraphContextStorage {
-    OAG::Graph::Context context;
+    OAG::Graph graph;
 };
 
 OAG_ASSUME_NONNULL_END

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraphCxx/Graph/Subgraph.hpp
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraphCxx/Graph/Subgraph.hpp
@@ -19,8 +19,9 @@ class SubgraphObject;
 
 class Subgraph final {
 private:
-    OAGSubgraphRef _cf_subgraph;
-    OAGGraphContextStorage& _context;
+    SubgraphObject *_Nullable _object;
+    Graph& _graph;
+    OAGUniqueID _graph_context_id;
     // TODO
     bool _isInvalid;
     static pthread_key_t _current_subgraph_key;
@@ -30,7 +31,7 @@ public:
     static Subgraph *from_cf(OAGSubgraphRef cf_subgraph) OAG_NOEXCEPT;
     
     OAGSubgraphRef to_cf() const OAG_NOEXCEPT {
-        return _cf_subgraph;
+        return reinterpret_cast<OAGSubgraphRef>(_object);
     }
     
     // MARK: - pthread related
@@ -75,13 +76,13 @@ public:
     // MARK: - Getter and setter
     
     OAG_INLINE OAG_CONSTEXPR
-    const OAGGraphContextRef get_context() const OAG_NOEXCEPT {
-        return &_context;
+    const OAG::Graph &get_graph() const OAG_NOEXCEPT {
+        return _graph;
     }
-    
+
     OAG_INLINE OAG_CONSTEXPR
-    OAGGraphContextRef get_context() OAG_NOEXCEPT {
-        return &_context;
+    OAG::Graph &get_graph() OAG_NOEXCEPT {
+        return _graph;
     }
     
     OAG_INLINE OAG_CONSTEXPR
@@ -98,7 +99,7 @@ public:
 
 struct OAGSubgraphStorage {
     CFRuntimeBase base;
-    OAG::Subgraph *subgraph;
+    OAG::Subgraph *_Nullable subgraph;
 };
 
 namespace OAG {

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraphCxx/Graph/Subgraph.hpp
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraphCxx/Graph/Subgraph.hpp
@@ -12,6 +12,8 @@
 #include <OpenAttributeGraphCxx/Runtime/metadata.hpp>
 #include <pthread.h>
 
+OAG_ASSUME_NONNULL_BEGIN
+
 typedef struct OAG_BRIDGED_TYPE(id) OAGSubgraphStorage * OAGSubgraphRef;
 
 namespace OAG {
@@ -28,9 +30,9 @@ private:
 public:
     // MARK: - CF related
     
-    static Subgraph *from_cf(OAGSubgraphRef cf_subgraph) OAG_NOEXCEPT;
+    static Subgraph *_Nullable from_cf(OAGSubgraphRef cf_subgraph) OAG_NOEXCEPT;
     
-    OAGSubgraphRef to_cf() const OAG_NOEXCEPT {
+    _Nullable OAGSubgraphRef to_cf() const OAG_NOEXCEPT {
         return reinterpret_cast<OAGSubgraphRef>(_object);
     }
     
@@ -47,12 +49,12 @@ public:
     }
     
     OAG_INLINE OAG_CONSTEXPR
-    static Subgraph *get_current() OAG_NOEXCEPT {
+    static Subgraph *_Nullable get_current() OAG_NOEXCEPT {
         return (OAG::Subgraph*)pthread_getspecific(OAG::Subgraph::current_key());
     }
     
     OAG_INLINE OAG_CONSTEXPR
-    static int set_current(Subgraph *subgraph) OAG_NOEXCEPT {
+    static int set_current(Subgraph *_Nullable subgraph) OAG_NOEXCEPT {
         return pthread_setspecific(OAG::Subgraph::current_key(), subgraph);
     }
     
@@ -109,3 +111,5 @@ class SubgraphObject final {
 }
 
 #endif /* Subgraph_hpp */
+
+OAG_ASSUME_NONNULL_END


### PR DESCRIPTION
This adds a `OGUnownedGraphContextRef` type which is actually a pointer to a `OG::Graph` instance.

The `OGSubgraphGetGraph` function, which is now unimplemented, needs to look up the OG::Graph::Context instance from a map of context IDs to Context instances stored on the OG::Graph instance.

The one inconsistency is `OGGraphContextGetGraph` which still takes a raw pointer to a `OG::Graph::Context` instance. Though this function is only called from AGSubgraphGetGraph and looks to be inlined.