### PR TITLE
Metadata interface updates

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git",
       "state" : {
         "branch" : "main",
-        "revision" : "09f6bd3d766b0fd99aa67bdcacd3105bf508a7c4"
+        "revision" : "4aa30d65aae91b8cd3aa7e6b5910d281a77e9af0"
       }
     },
     {

--- a/Sources/OpenGraph/Runtime/Metadata.swift
+++ b/Sources/OpenGraph/Runtime/Metadata.swift
@@ -7,46 +7,38 @@
 
 public import OpenGraphCxx
 #if canImport(ObjectiveC)
-public import Foundation
+import Foundation
 #endif
 
 @_silgen_name("OGTypeApplyFields")
-public func OGTypeApplyFields(
-    _ type: Any.Type,
+private func OGTypeApplyFields(
+    of type: Any.Type,
     body: (UnsafePointer<Int8>, Int, Any.Type) -> Void
 )
 
 @_silgen_name("OGTypeApplyFields2")
-public func OGTypeApplyFields2(
-    _ type: Any.Type,
-    options: OGTypeApplyOptions,
+private func OGTypeApplyFields2(
+    of type: Any.Type,
+    options: Metadata.ApplyOptions,
     body: (UnsafePointer<Int8>, Int, Any.Type) -> Bool
 ) -> Bool
 
-@inlinable
-@inline(__always)
 public func forEachField(
-    _ type: Any.Type,
+    of type: Any.Type,
     do body: (UnsafePointer<Int8>, Int, Any.Type) -> Void
 ) {
-    OGTypeApplyFields(type, body: body)
+    OGTypeApplyFields(of: type, body: body)
 }
 
 extension Metadata: Swift.Hashable, Swift.CustomStringConvertible {
-    @inlinable
-    @inline(__always)
     public init(_ type: any Any.Type) {
         self.init(rawValue: unsafeBitCast(type, to: UnsafePointer<_Metadata>.self))
     }
-    
-    @inlinable
-    @inline(__always)
+
     public var type: any Any.Type {
         unsafeBitCast(rawValue, to: Any.Type.self)
     }
-    
-    @inlinable
-    @inline(__always)
+
     public var description: String {
         #if canImport(ObjectiveC)
         __OGTypeDescription(self) as NSString as String
@@ -54,27 +46,16 @@ extension Metadata: Swift.Hashable, Swift.CustomStringConvertible {
         fatalError("Unimplemented")
         #endif
     }
-    
-    @inlinable
-    @inline(__always)
-    /* public */func forEachField(
-        do body: (UnsafePointer<Int8>, Int, Any.Type) -> Void
-    ) {
-        OGTypeApplyFields(type, body: body)
-    }
-    
-    @inlinable
-    @inline(__always)
+
     public func forEachField(
-        options: OGTypeApplyOptions,
+        options: ApplyOptions,
         do body: (UnsafePointer<Int8>, Int, Any.Type) -> Bool
     ) -> Bool {
-        OGTypeApplyFields2(type, options: options, body: body)
+        OGTypeApplyFields2(of: type, options: options, body: body)
     }
 }
 
-extension Signature: @retroactive Equatable {
-
+extension Signature: Equatable {
     public static func == (_ lhs: Signature, _ rhs: Signature) -> Bool {
         return lhs.bytes.0 == rhs.bytes.0 && lhs.bytes.1 == rhs.bytes.1
             && lhs.bytes.2 == rhs.bytes.2 && lhs.bytes.3 == rhs.bytes.3
@@ -87,5 +68,4 @@ extension Signature: @retroactive Equatable {
             && lhs.bytes.16 == rhs.bytes.16 && lhs.bytes.17 == rhs.bytes.17
             && lhs.bytes.18 == rhs.bytes.18 && lhs.bytes.19 == rhs.bytes.19
     }
-
 }

--- a/Sources/OpenGraph/Runtime/Metadata.swift
+++ b/Sources/OpenGraph/Runtime/Metadata.swift
@@ -23,6 +23,15 @@ public func OGTypeApplyFields2(
     body: (UnsafePointer<Int8>, Int, Any.Type) -> Bool
 ) -> Bool
 
+@inlinable
+@inline(__always)
+public func forEachField(
+    _ type: Any.Type,
+    do body: (UnsafePointer<Int8>, Int, Any.Type) -> Void
+) {
+    OGTypeApplyFields(type, body: body)
+}
+
 extension Metadata: Swift.Hashable, Swift.CustomStringConvertible {
     @inlinable
     @inline(__always)

--- a/Sources/OpenGraph/Runtime/Metadata.swift
+++ b/Sources/OpenGraph/Runtime/Metadata.swift
@@ -63,3 +63,20 @@ extension Metadata: Swift.Hashable, Swift.CustomStringConvertible {
         OGTypeApplyFields2(type, options: options, body: body)
     }
 }
+
+extension Signature: @retroactive Equatable {
+
+    public static func == (_ lhs: Signature, _ rhs: Signature) -> Bool {
+        return lhs.bytes.0 == rhs.bytes.0 && lhs.bytes.1 == rhs.bytes.1
+            && lhs.bytes.2 == rhs.bytes.2 && lhs.bytes.3 == rhs.bytes.3
+            && lhs.bytes.4 == rhs.bytes.4 && lhs.bytes.5 == rhs.bytes.5
+            && lhs.bytes.6 == rhs.bytes.6 && lhs.bytes.7 == rhs.bytes.7
+            && lhs.bytes.8 == rhs.bytes.8 && lhs.bytes.9 == rhs.bytes.9
+            && lhs.bytes.10 == rhs.bytes.10 && lhs.bytes.11 == rhs.bytes.11
+            && lhs.bytes.12 == rhs.bytes.12 && lhs.bytes.13 == rhs.bytes.13
+            && lhs.bytes.14 == rhs.bytes.14 && lhs.bytes.15 == rhs.bytes.15
+            && lhs.bytes.16 == rhs.bytes.16 && lhs.bytes.17 == rhs.bytes.17
+            && lhs.bytes.18 == rhs.bytes.18 && lhs.bytes.19 == rhs.bytes.19
+    }
+
+}

--- a/Sources/OpenGraph/Runtime/Metadata.swift
+++ b/Sources/OpenGraph/Runtime/Metadata.swift
@@ -55,7 +55,7 @@ extension Metadata: Swift.Hashable, Swift.CustomStringConvertible {
     }
 }
 
-extension Signature: Equatable {
+extension Signature: Swift.Equatable {
     public static func == (_ lhs: Signature, _ rhs: Signature) -> Bool {
         return lhs.bytes.0 == rhs.bytes.0 && lhs.bytes.1 == rhs.bytes.1
             && lhs.bytes.2 == rhs.bytes.2 && lhs.bytes.3 == rhs.bytes.3

--- a/Sources/OpenGraphCxx/include/OpenGraph/OGTypeID.h
+++ b/Sources/OpenGraphCxx/include/OpenGraph/OGTypeID.h
@@ -37,7 +37,7 @@ typedef OG_OPTIONS(uint32_t, OGTypeApplyOptions) {
     OGTypeApplyOptionsEnumerateClassFields = 1 << 0,
     OGTypeApplyOptionsContinueAfterUnknownField = 1 << 1,
     OGTypeApplyOptionsEnumerateEnumCases = 1 << 2,
-};
+} OG_SWIFT_NAME(Metadata.ApplyOptions);
 
 #if OPENGRAPH_RELEASE >= OPENGRAPH_RELEASE_2024
 

--- a/Sources/OpenGraphShims/GraphShims.swift
+++ b/Sources/OpenGraphShims/GraphShims.swift
@@ -8,7 +8,6 @@ public typealias OGAttributeInfo = AGAttributeInfo
 public typealias OGCachedValueOptions = AGCachedValueOptions
 public typealias OGChangedValueFlags = AGChangedValueFlags
 public typealias OGInputOptions = AGInputOptions
-public typealias OGTypeApplyOptions = AGTypeApplyOptions
 public typealias OGUniqueID = AGUniqueID
 public typealias OGValue = AGValue
 public typealias OGValueOptions = AGValueOptions

--- a/Tests/OpenGraphCompatibilityTests/GraphShims.swift
+++ b/Tests/OpenGraphCompatibilityTests/GraphShims.swift
@@ -8,7 +8,6 @@ public typealias OGAttributeInfo = AGAttributeInfo
 public typealias OGCachedValueOptions = AGCachedValueOptions
 public typealias OGChangedValueFlags = AGChangedValueFlags
 public typealias OGInputOptions = AGInputOptions
-public typealias OGTypeApplyOptions = AGTypeApplyOptions
 public typealias OGUniqueID = AGUniqueID
 public typealias OGValue = AGValue
 public typealias OGValueOptions = AGValueOptions


### PR DESCRIPTION
This makes the Swift refinement for OGTypeApplyFields a top level function to match the demangled signature:

```
AttributeGraph.forEachField(of: Any.Type, do: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, Any.Type) -> ()) -> (),
```