### PR TITLE
Refactor AttributeGraphVendor to RawRepresentable struct

### DIFF
--- a/Sources/OpenAttributeGraphShims/GraphShims.swift
+++ b/Sources/OpenAttributeGraphShims/GraphShims.swift
@@ -2,10 +2,26 @@
 //  GraphShims.swift
 //  OpenAttributeGraphShims
 
-public enum AttributeGraphVendor: String {
-    case oag = "org.OpenSwiftUIProject.OpenAttributeGraph"
-    case ag = "com.apple.AttributeGraph"
-    case compute = "dev.incrematic.compute"
+/// A type that identifies the underlying attribute graph implementation vendor.
+///
+/// Use `attributeGraphVendor` to check which vendor is active at runtime.
+public struct AttributeGraphVendor: RawRepresentable, Hashable, CaseIterable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    /// OpenAttributeGraph — the open-source implementation by OpenSwiftUIProject.
+    public static let oag = AttributeGraphVendor(rawValue: "org.OpenSwiftUIProject.OpenAttributeGraph")
+
+    /// Apple's private AttributeGraph framework.
+    public static let ag = AttributeGraphVendor(rawValue: "com.apple.AttributeGraph")
+
+    /// An incremental computation library for Swift by @jcmosc
+    public static let compute = AttributeGraphVendor(rawValue: "dev.incrematic.compute")
+
+    public static var allCases: [AttributeGraphVendor] { [.oag, .ag, .compute] }
 }
 
 #if OPENATTRIBUTEGRAPH_COMPUTE

--- a/Sources/OpenAttributeGraphShims/OAGShims.swift
+++ b/Sources/OpenAttributeGraphShims/OAGShims.swift
@@ -1,5 +1,5 @@
 //
-//  GraphShims.swift
+//  AGShims.swift
 //  OpenAttributeGraphShims
 
 /// A type that identifies the underlying attribute graph implementation vendor.

--- a/Tests/OpenAttributeGraphCompatibilityTests/OAGShims.swift
+++ b/Tests/OpenAttributeGraphCompatibilityTests/OAGShims.swift
@@ -1,5 +1,5 @@
 //
-//  GraphShims.swift
+//  OAGShims.swift
 //  OpenAttributeGraphCompatibilityTests
 
 #if OPENATTRIBUTEGRAPH


### PR DESCRIPTION
## Summary
- Refactor `AttributeGraphVendor` from a `String`-backed enum to a struct conforming to `RawRepresentable` and `CaseIterable`, aligning with the pattern used by `RenderBoxVendor`
- Add DocC comments for the type and each vendor case

## Test plan
- [ ] Verify `OPENATTRIBUTEGRAPH_COMPATIBILITY_TEST=0 swift build` succeeds
- [ ] Verify `OPENATTRIBUTEGRAPH_COMPATIBILITY_TEST=1 swift build` succeeds
- [ ] Confirm downstream OpenSwiftUI builds without changes (API is source-compatible)