### PR TITLE
Make AttributeBodyVisitor visit mutating

### DIFF
--- a/Sources/OpenAttributeGraph/Attribute/Body/AttributeBodyVisitor.swift
+++ b/Sources/OpenAttributeGraph/Attribute/Body/AttributeBodyVisitor.swift
@@ -5,5 +5,5 @@
 //  Status: WIP
 
 public protocol AttributeBodyVisitor {
-    func visit<Body: _AttributeBody>(body: UnsafePointer<Body>)
+    mutating func visit<Body: _AttributeBody>(body: UnsafePointer<Body>)
 }

--- a/Sources/OpenAttributeGraphShims/Adapter/DanceUIGraph.swift
+++ b/Sources/OpenAttributeGraphShims/Adapter/DanceUIGraph.swift
@@ -9,7 +9,6 @@
 @_exported public import DanceUIRuntime
 @_exported public import DanceUIGraph
 
-public typealias AttributeBodyVisitor = DanceUIGraph.AttributeBodyVisitor
 public typealias ComparisonMode = DGComparisonMode
 public typealias GraphContext = DGGraphContextRef
 public typealias Metadata = DGTypeID


### PR DESCRIPTION
## Summary
- Mark `AttributeBodyVisitor.visit` as `mutating` so visitor implementations can keep state while traversing attribute bodies.