### PR TITLE
Update Compute binary to 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a7c6d7187819e0ca9c7143253d92733a30046affa5e7e9c2aec1699e503ad330",
+  "originHash" : "1d0b96dd6c902456e70c73aeb9ebe582850c08a12c02b6bb789138c3c46c93d4",
   "pins" : [
     {
       "identity" : "swift-numerics",

--- a/Package.swift
+++ b/Package.swift
@@ -430,11 +430,10 @@ func setupDPFDependency() {
 if computeCondition {
     let binary = envBoolValue("OPENATTRIBUTESHIMS_COMPUTE_BINARY", default: false)
     if binary {
-        // FIXME: This version is broken and will have runtime crash
-        let version = envStringValue("OPENATTRIBUTESHIMS_COMPUTE_BINARY_VERSION", default: "0.2.1")
+        let version = envStringValue("OPENATTRIBUTESHIMS_COMPUTE_BINARY_VERSION", default: "0.3.0")
         let repo = envStringValue("OPENATTRIBUTESHIMS_COMPUTE_BINARY_REPO", default: "jcmosc/Compute")
         let url = envStringValue("OPENATTRIBUTESHIMS_COMPUTE_BINARY_URL", default: "https://github.com/\(repo)/releases/download/\(version)/Compute.xcframework.zip")
-        let checksum = envStringValue("OPENATTRIBUTESHIMS_COMPUTE_BINARY_CHECKSUM", default: "44eb3f08b9da4e7e308bfb2654b36e6752547e8ba5ec33e19e0648c686990153")
+        let checksum = envStringValue("OPENATTRIBUTESHIMS_COMPUTE_BINARY_CHECKSUM", default: "d1e76d9fee3b2995c2b21e3cc95cf6157e827408f701439b3dd34795dd95dee1")
         package.targets.append(
             .binaryTarget(
                 name: "Compute",

--- a/Sources/OpenAttributeGraphShims/Adapter/Compute.swift
+++ b/Sources/OpenAttributeGraphShims/Adapter/Compute.swift
@@ -6,12 +6,12 @@
 
 @_exported public import Compute
 
-public typealias OAGAttributeInfo = AGAttributeInfo
+public typealias OAGAttributeInfo = IAGAttributeInfo
 public typealias OAGCachedValueOptions = CachedValueOptions
-public typealias OAGChangedValueFlags = AGChangedValueFlags
-public typealias OAGInputOptions = AGInputOptions
-public typealias OAGValue = AGChangedValue
-public typealias OAGValueOptions = AGValueOptions
+public typealias OAGChangedValueFlags = IAGChangedValueFlags
+public typealias OAGInputOptions = IAGInputOptions
+public typealias OAGValue = IAGChangedValue
+public typealias OAGValueOptions = IAGValueOptions
 
 extension AnyAttribute {
     public typealias Flags = Subgraph.Flags


### PR DESCRIPTION
## Summary

- Update the default Compute binary dependency from 0.2.1 to 0.3.0.
- Refresh the SwiftPM binary target checksum for `Compute.xcframework.zip`.
- Keep the regenerated `Package.resolved` origin hash in sync with the manifest.

## Validation

- Verified the 0.3.0 `Compute.xcframework.zip` checksum with `swift package compute-checksum`.
- `OPENATTRIBUTEGRAPH_OPENATTRIBUTESHIMS_COMPUTE=1 OPENATTRIBUTEGRAPH_OPENATTRIBUTESHIMS_COMPUTE_BINARY=1 swift package dump-package`
- `git diff --check`